### PR TITLE
IMP pack avroc lib into pyavroc wheel

### DIFF
--- a/pyavroc/_version.py
+++ b/pyavroc/_version.py
@@ -1,1 +1,1 @@
-__version__ = '0.7.2.tubular0'
+__version__ = '0.7.2.tubular2'

--- a/setup.py
+++ b/setup.py
@@ -37,18 +37,27 @@ if cflags:
 
 extra_libs = os.environ.get('PYAVROC_LIBS', '').split()
 
-ext_modules = [Extension('pyavroc/_pyavroc',
-                         ['src/pyavro.c',
-                          'src/filereader.c',
-                          'src/filewriter.c',
-                          'src/serializer.c',
-                          'src/deserializer.c',
-                          'src/convert.c',
-                          'src/record.c',
-                          'src/avroenum.c',
-                          'src/util.c',
-                          'src/error.c'],
-                         libraries=['avro'] + extra_libs)]
+ext_modules = [
+    Extension(
+        'pyavroc/_pyavroc',
+        [
+            'src/pyavro.c',
+            'src/filereader.c',
+            'src/filewriter.c',
+            'src/serializer.c',
+            'src/deserializer.c',
+            'src/convert.c',
+            'src/record.c',
+            'src/avroenum.c',
+            'src/util.c',
+            'src/error.c'
+        ],
+        libraries=['avro'] + extra_libs,
+        include_dirs=['/usr/include', '/usr/local/include'],
+        library_dirs=['/usr/lib', '/usr/local/lib'],
+        runtime_library_dirs=['/usr/lib', '/usr/local/lib'],
+    )
+]
 
 setup(name='pyavroc',
       version=version,
@@ -60,7 +69,7 @@ setup(name='pyavroc',
       long_description=long_description,
       keywords='avro serialization',
       platforms='any',
-      classifiers = [
+      classifiers=[
           'Development Status :: 4 - Beta',
           'Intended Audience :: Developers',
           'License :: OSI Approved :: Apache Software License',
@@ -71,5 +80,34 @@ setup(name='pyavroc',
       ],
       tests_require=['pytest'],
       packages=['pyavroc'],
-      package_data={'pyavroc': ['avro/NOTICE.txt']},  # in case it was included
+      package_data={
+          'pyavroc': [
+              'avro/NOTICE.txt'
+          ],
+      },  # in case it was included
+      data_files=[
+        ('lib', [
+            '/usr/lib/libavro.so.24.0.0',  # Tubular/avro lib
+            '/usr/lib/libavro.so',
+            '/usr/lib/libavro.a'
+        ]),
+        ('include', ['/usr/include/avro.h']),
+        ('include/avro', [
+            '/usr/include/avro/allocation.h',
+            '/usr/include/avro/basics.h',
+            '/usr/include/avro/consumer.h',
+            '/usr/include/avro/data.h',
+            '/usr/include/avro/errors.h',
+            '/usr/include/avro/generic.h',
+            '/usr/include/avro/io.h',
+            '/usr/include/avro/legacy.h',
+            '/usr/include/avro/msinttypes.h',
+            '/usr/include/avro/msstdint.h',
+            '/usr/include/avro/platform.h',
+            '/usr/include/avro/refcount.h',
+            '/usr/include/avro/resolver.h',
+            '/usr/include/avro/schema.h',
+            '/usr/include/avro/value.h',
+        ]),
+      ],
       ext_modules=ext_modules)


### PR DESCRIPTION
To avoid mess with deb/rpm packages dependencies we need to
pack *.so libs and *.h includes into pyavroc wheels. This
will allow us to safely release pyavroc package and be sure
that each package will be linked with correct avroc lib.