### PR TITLE
FIX libavro static linkage

### DIFF
--- a/build_pyavroc.sh
+++ b/build_pyavroc.sh
@@ -16,20 +16,72 @@
 
 set -eux
 
+STATIC=0
+[ "${1:-}" = '--static' ] && STATIC=1
+
+cd $(dirname "$0")
+
 MYDIR=$(/bin/pwd)
+
+AVRO=$MYDIR/local_avro
+
+[ -d $AVRO ] || git clone -b patches http://github.com/Tubular/avro $(basename $AVRO)
+
+# build avro
+
+if ! [ -f $AVRO/dist/lib/libavro.a ] && ! [ -f $AVRO/dist/lib/libavro.so ]
+then
+    # libavro.a must contain PIC
+    mv -n $AVRO/lang/c/src/CMakeLists.txt $AVRO/lang/c/src/orig_CMakeLists
+    cp -v $AVRO/lang/c/src/orig_CMakeLists $AVRO/lang/c/src/CMakeLists.txt
+    echo 'set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_SHARED_LIBRARY_C_FLAGS}")' >>$AVRO/lang/c/src/CMakeLists.txt
+
+    mkdir -p $AVRO/build $AVRO/dist
+    cd $AVRO/build
+    cmake $AVRO/lang/c -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_INSTALL_PREFIX=$AVRO/dist -DCMAKE_BUILD_TYPE=Release -DTHREADSAFE=true
+    make
+    make test
+    # workaround older cmake
+    mv $AVRO/build/avro-c.pc $AVRO/build/src/ || true
+    make install
+
+    # use static lib
+    [ $STATIC -eq 0 ] || rm -f $AVRO/dist/lib/libavro.so*
+fi
 
 PYTHON=${PYTHON:-python3.5}
 
-# avro lib to link,
-# passed as an argument, e.g `./build_pyavroc.sh libavro.so.22.0.0`
-LIBAVRO=$1
+# build avro python
+
+case $($PYTHON -c 'import sys; print(sys.version_info.major)') in
+    3) AVROPY=$AVRO/lang/py3
+        ;;
+    *) AVROPY=$AVRO/lang/py
+       ;;
+esac
+
+cd $AVROPY
+
+rm -rf build
+$PYTHON setup.py build
+
+# build pyavroc
 
 cd $MYDIR
 
 rm -rf build dist
 
-export PYAVROC_CFLAGS="-I/usr/include/avro"
-export LDFLAGS="-L/usr/lib/$LIBAVRO -Wl,-rpath,/usr/lib/$LIBAVRO"
+export PYAVROC_CFLAGS="-I$AVRO/dist/include"
+if [ $STATIC -ne 0 ]
+then
+    mkdir -p pyavroc/avro
+    cp -v local_avro/NOTICE.txt pyavroc/avro/
+    # a bit cheesy: get libraries from the cmake link.txt file
+    export PYAVROC_LIBS=$(tr ' ' '\n' <$AVRO/build/src/CMakeFiles/avro-shared.dir/link.txt | grep '^-l' | cut -c3-)
+    export LDFLAGS="-L$AVRO/dist/lib"
+else
+    export LDFLAGS="-L$AVRO/dist/lib -Wl,-rpath,$AVRO/dist/lib"
+fi
 
 $PYTHON setup.py build
 
@@ -37,11 +89,11 @@ cd build/lib*/pyavroc
 
 cd $MYDIR
 
-export PYTHONPATH=$(echo $MYDIR/build/lib*)
+export PYTHONPATH=$(echo $MYDIR/build/lib*):$(echo $AVROPY/build/lib*)
+
 cd tests
 
 $PYTHON -m pytest -sv .
 
 cd $MYDIR
-
 $PYTHON setup.py bdist_wheel

--- a/pyavroc/_version.py
+++ b/pyavroc/_version.py
@@ -1,1 +1,1 @@
-__version__ = '0.7.2.tubular2'
+__version__ = '0.7.2.tubular3'

--- a/setup.py
+++ b/setup.py
@@ -37,27 +37,18 @@ if cflags:
 
 extra_libs = os.environ.get('PYAVROC_LIBS', '').split()
 
-ext_modules = [
-    Extension(
-        'pyavroc/_pyavroc',
-        [
-            'src/pyavro.c',
-            'src/filereader.c',
-            'src/filewriter.c',
-            'src/serializer.c',
-            'src/deserializer.c',
-            'src/convert.c',
-            'src/record.c',
-            'src/avroenum.c',
-            'src/util.c',
-            'src/error.c'
-        ],
-        libraries=['avro'] + extra_libs,
-        include_dirs=['/usr/include', '/usr/local/include'],
-        library_dirs=['/usr/lib', '/usr/local/lib'],
-        runtime_library_dirs=['/usr/lib', '/usr/local/lib'],
-    )
-]
+ext_modules = [Extension('pyavroc/_pyavroc',
+                         ['src/pyavro.c',
+                          'src/filereader.c',
+                          'src/filewriter.c',
+                          'src/serializer.c',
+                          'src/deserializer.c',
+                          'src/convert.c',
+                          'src/record.c',
+                          'src/avroenum.c',
+                          'src/util.c',
+                          'src/error.c'],
+                         libraries=['avro'] + extra_libs)]
 
 setup(name='pyavroc',
       version=version,
@@ -80,34 +71,5 @@ setup(name='pyavroc',
       ],
       tests_require=['pytest'],
       packages=['pyavroc'],
-      package_data={
-          'pyavroc': [
-              'avro/NOTICE.txt'
-          ],
-      },  # in case it was included
-      data_files=[
-        ('lib', [
-            '/usr/lib/libavro.so.24.0.0',  # Tubular/avro lib
-            '/usr/lib/libavro.so',
-            '/usr/lib/libavro.a'
-        ]),
-        ('include', ['/usr/include/avro.h']),
-        ('include/avro', [
-            '/usr/include/avro/allocation.h',
-            '/usr/include/avro/basics.h',
-            '/usr/include/avro/consumer.h',
-            '/usr/include/avro/data.h',
-            '/usr/include/avro/errors.h',
-            '/usr/include/avro/generic.h',
-            '/usr/include/avro/io.h',
-            '/usr/include/avro/legacy.h',
-            '/usr/include/avro/msinttypes.h',
-            '/usr/include/avro/msstdint.h',
-            '/usr/include/avro/platform.h',
-            '/usr/include/avro/refcount.h',
-            '/usr/include/avro/resolver.h',
-            '/usr/include/avro/schema.h',
-            '/usr/include/avro/value.h',
-        ]),
-      ],
+      package_data={'pyavroc': ['avro/NOTICE.txt']},  # in case it was included
       ext_modules=ext_modules)


### PR DESCRIPTION
Packing *.so into a wheel  wasn't a good idea, as we became dependent on python's
"sys.exec_prefix". This approach isn't working when installing the package in
virtualenv. Seems like the best solution for us is to use static linkage
for libavro.